### PR TITLE
Add chai as a test dependency to test requiring node_modules

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -10,5 +10,8 @@
     "hiredis": "^0.2.0",
     "mocha": "^2.2.1",
     "redis": "^0.12.1"
+  },
+  "devDependencies": {
+    "chai": "^2.2.0"
   }
 }

--- a/node/test/dummyTest.js
+++ b/node/test/dummyTest.js
@@ -1,4 +1,4 @@
-var assert = require("assert");
+var assert = require("chai").assert;
 
 describe('Dummy Test', function(){
     it('should pass', function(){


### PR DESCRIPTION
The mocha that's used on CircleCI is a global one already on the virtual machine. Looks like anything required from `node_modules` isn't found during the test step. This PR is to demonstrate the failure, and so that you can see the logs.
