### PR TITLE
Vagranfile added for vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node/node_modules
 .DS_Store
 
 node/npm-debug.log
+.vagrant

--- a/README.md
+++ b/README.md
@@ -8,4 +8,5 @@ For a detailed explanation of the workflow used in this repository, refer to [th
 For a detailed overview of Containers and Docker, refer to [this post from my blog](http://anandmanisankar.com/posts/container-docker-PaaS-microservices/):
 [http://anandmanisankar.com/posts/container-docker-PaaS-microservices/](http://anandmanisankar.com/posts/container-docker-PaaS-microservices/)
 
-
+A Vagrantfile has been added for developing purposes, just install vagrant and run "vagrant up":
+[https://www.vagrantup.com/downloads.html](https://www.vagrantup.com/downloads.html)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+unless Vagrant.has_plugin?("vagrant-docker-compose")
+  system("vagrant plugin install vagrant-docker-compose")
+  puts "Dependencies installed, please try the command again."
+  exit
+end
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty64"
+  #config.vm.box = "box-cutter/centos70-docker"
+
+  config.vm.network(:forwarded_port, guest: 80, host: 9080)
+
+  config.vm.provision :shell, inline: "apt-get update"
+  #config.vm.provision :shell, inline: "yum clean all; yum makecache fast; yum -y update"
+  config.vm.provision :docker
+  config.vm.provision :docker_compose, yml: "/vagrant/docker-compose.yml", rebuild: true, project_name: "myproject", run: "always"
+end


### PR DESCRIPTION
Vagrant allowed me to create an docker host on my Mac then apply docker compose as designed. I tested this on Ubuntu and Centos 7 as docker hosts. Vagrant up will bring the environment up, and forward the port 80 to 9080, so after vagrant up finish you can go in to your browser and go to http://localhost:9080, then you can do vagrant destroy, vagrant snapshot as desired, excellent for development, at least works great for me. Let me know if you have any question.
